### PR TITLE
添加 left-pad 事件

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - [In Defense of Hyper Modular JavaScript – freeCodeCamp.org](https://medium.freecodecamp.org/in-defense-of-hyper-modular-javascript-33934c79e113)
 
 【思考】
-- One-line module 好还是不好，https://github.com/sindresorhus/ama/issues/10
+- One-line module 好还是不好，[sindresorhus/ama#10](https://github.com/sindresorhus/ama/issues/10)、[sindresorhus/ama#367](https://github.com/sindresorhus/ama/issues/367)
 - DRY 原则的拿捏程度
 - npm 平台的稳定性
 - npm 包的信息安全警戒，[我是这样黑进你Node.js生产服务器的 - 掘金](https://juejin.im/post/5b8b37c951882542a82ba60c)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Performance-Art
+
+#### 【2016-03-22】因不满版权威胁，npm 包 left-pad 作者公然删库，导致 babel、react 等技术栈权限崩溃
+
+【链接】
+- [如何看待 Azer Koçulu 删除了自己的所有 npm 库？ - 知乎](https://www.zhihu.com/question/41694868)
+- [从 left-pad 事件我们可以学到什么 - 前端涨姿势 - SegmentFault 思否](https://segmentfault.com/a/1190000004700432)
+- [NPM & left-pad: Have We Forgotten How To Program?](https://www.davidhaney.io/npm-left-pad-have-we-forgotten-how-to-program/)
+- [In Defense of Hyper Modular JavaScript – freeCodeCamp.org](https://medium.freecodecamp.org/in-defense-of-hyper-modular-javascript-33934c79e113)
+
+【思考】
+- One-line module 好还是不好，https://github.com/sindresorhus/ama/issues/10
+- DRY 原则的拿捏程度
+- npm 平台的稳定性
+- npm 包的信息安全警戒，[我是这样黑进你Node.js生产服务器的 - 掘金](https://juejin.im/post/5b8b37c951882542a82ba60c)


### PR DESCRIPTION
#### 【2016-03-22】因不满版权威胁，npm 包 left-pad 作者公然删库，导致 babel、react 等技术栈权限崩溃

【链接】
- [如何看待 Azer Koçulu 删除了自己的所有 npm 库？ - 知乎](https://www.zhihu.com/question/41694868)
- [从 left-pad 事件我们可以学到什么 - 前端涨姿势 - SegmentFault 思否](https://segmentfault.com/a/1190000004700432)
- [NPM & left-pad: Have We Forgotten How To Program?](https://www.davidhaney.io/npm-left-pad-have-we-forgotten-how-to-program/)
- [In Defense of Hyper Modular JavaScript – freeCodeCamp.org](https://medium.freecodecamp.org/in-defense-of-hyper-modular-javascript-33934c79e113)

【思考】
- One-line module 好还是不好，[sindresorhus/ama#10](https://github.com/sindresorhus/ama/issues/10)、[sindresorhus/ama#367](https://github.com/sindresorhus/ama/issues/367)
- DRY 原则的拿捏程度
- npm 平台的稳定性
- npm 包的信息安全警戒，[我是这样黑进你Node.js生产服务器的 - 掘金](https://juejin.im/post/5b8b37c951882542a82ba60c)